### PR TITLE
Problem: Printiest doesn't work with modern Lean4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /build
+/lean_packages

--- a/Printiest.lean
+++ b/Printiest.lean
@@ -1,4 +1,4 @@
 import Printiest.Tests
 
-def main : IO Unit :=   
-  IO.Prim.getStdout >>= bigSexpr2.pretty.renderStream 80
+def main : IO Unit := do
+  (IO.getStdout >>= bigSexpr2.pretty.renderStreamB 80) |>.toIO

--- a/Printiest/Measure.lean
+++ b/Printiest/Measure.lean
@@ -7,82 +7,82 @@ open Std (DList)
 Note: all of the comparisons (equality, LE, etc) use ONLY the
 measure's dimensions; we're not concerned with the choices.
 -/
-structure Measure where
+structure Measure' where
 (height : Nat)
 (maxWidth : Nat)
 (lastWidth : Nat)
 (choices : DList Choice)
 
-instance Measure.Inhabited : Inhabited Measure where
+instance Measure'.Inhabited : Inhabited Measure' where
   default := ⟨0, 0, 0, DList.empty⟩
 
-instance : Ord Measure where
+instance : Ord Measure' where
   compare a b :=
   match Ord.compare a.height b.height with
   | Ordering.lt => Ordering.lt
   | Ordering.gt => Ordering.gt
-  | Ordering.eq => 
+  | Ordering.eq =>
     match Ord.compare a.maxWidth b.maxWidth with
     | Ordering.lt => Ordering.lt
     | Ordering.gt => Ordering.gt
     | Ordering.eq => Ord.compare a.lastWidth b.lastWidth
 
-instance : LE Measure :=
-  ⟨fun m1 m2 => 
+instance : LE Measure' :=
+  ⟨fun m1 m2 =>
   match Ord.compare m1 m2 with
   | Ordering.lt => True
   | Ordering.eq => True
   | _ => False⟩
 
-instance : LT Measure := ⟨fun m1 m2 => Ord.compare m1 m2 = Ordering.lt⟩
+instance : LT Measure' := ⟨fun m1 m2 => Ord.compare m1 m2 = Ordering.lt⟩
 
-instance Measure.decLe (m1 m2 : Measure) : Decidable (LE.le m1 m2) := 
+instance Measure'.decLe (m1 m2 : Measure') : Decidable (LE.le m1 m2) :=
   match h:Ord.compare m1 m2 with
   | Ordering.lt => by
-    simp only [LE.le, h] 
+    simp only [LE.le, h]
     exact (isTrue trivial)
   | Ordering.gt => by
-    simp only [LE.le, h] 
+    simp only [LE.le, h]
     exact (isFalse id)
   | Ordering.eq => by
     simp only [LE.le, h]
     exact (isTrue trivial)
 
-def Measure.lt (s1 s2 : Measure) : Bool :=
+def Measure'.lt (s1 s2 : Measure') : Bool :=
 match Ord.compare s1 s2 with
 | Ordering.lt => true
 | _ => false
 
-def Measure.dominates (s t : Measure) : Bool := 
+def Measure'.dominates (s t : Measure') : Bool :=
   s.height <= t.height
   && s.maxWidth <= t.maxWidth
   && s.lastWidth <= t.lastWidth
 
-def Measure.toString (m : Measure) : String := s!"⟨{m.height}, {m.maxWidth}, {m.lastWidth}, {m.choices.toList}⟩"
-instance : ToString Measure := ⟨Measure.toString⟩
+def Measure'.toString (m : Measure') : String := s!"⟨{m.height}, {m.maxWidth}, {m.lastWidth}, {m.choices.toList}⟩"
+instance : ToString Measure' := ⟨Measure'.toString⟩
 
-def Measure.beq (m1 m2 : Measure) : Bool := 
+def Measure'.beq (m1 m2 : Measure') : Bool :=
   match Ord.compare m1 m2 with
   | Ordering.eq => true
   | _ => false
 
-instance : BEq Measure := ⟨Measure.beq⟩
+instance : BEq Measure' := ⟨Measure'.beq⟩
 
-def Measure.text (s : String) : Measure := ⟨0, s.length, s.length, DList.empty⟩
+def Measure'.text (s : String) : Measure' := ⟨0, s.length, s.length, DList.empty⟩
 
-def Measure.concat (l r : Measure) : Measure := 
-  ⟨l.height + r.height, 
+def Measure'.concat (l r : Measure') : Measure' :=
+  ⟨l.height + r.height,
   l.maxWidth.max (l.lastWidth + r.maxWidth),
   l.lastWidth + r.lastWidth,
   l.choices ++ r.choices⟩
 
-def Measure.flush (m : Measure) : Measure := ⟨m.height.succ, m.maxWidth, 0, m.choices⟩
+def Measure'.flush (m : Measure') : Measure' := ⟨m.height.succ, m.maxWidth, 0, m.choices⟩
 
-def Measure.fits (m: Measure) (width : Nat) : Bool := m.maxWidth <= width
+def Measure'.fits (m: Measure') (width : Nat) : Bool := m.maxWidth <= width
 
-def Measure.cons (m : Measure) (c : Choice) : Measure := { m with choices := m.choices.cons c }
+def Measure'.cons (m : Measure') (c : Choice) : Measure' := { m with choices := m.choices.cons c }
 
-def Measure.vConcat (l r : Measure) : Measure := l.flush.concat r
+def Measure'.vConcat (l r : Measure') : Measure' := l.flush.concat r
 
 /-
   the end goal is some document that's a combination of a, b, and c.
@@ -98,10 +98,10 @@ def Measure.vConcat (l r : Measure) : Measure := l.flush.concat r
   then we need to detect that and abandon the horizontal grouping altogether, using
   vertical grouping instead.
 -/
-def zeroHeights (grps : Array (Nat × (Array Measure))) : Option (Array (Array Measure)) :=
+def zeroHeights (grps : Array (Nat × (Array Measure'))) : Option (Array (Array Measure')) :=
   let zeroes_only := grps.map (fun ⟨_, grp⟩ => grp.filterMap (fun s => if s.height = 0 then some s else none))
-  if zeroes_only.any (fun grp => grp.size = 0) 
-  then none 
+  if zeroes_only.any (fun grp => grp.size = 0)
+  then none
   else some zeroes_only
 
 
@@ -109,7 +109,7 @@ def arrayBind {A B : Type} (xs : Array A) (f : A -> Array B) : Array B :=
   xs.foldl (fun sink next => sink ++ f next) #[]
 
 /--
-from [x1, x2, .. xn], [y1, y2, .. yn] make [f x1 y1, f x1 y2, .. f xn yn] 
+from [x1, x2, .. xn], [y1, y2, .. yn] make [f x1 y1, f x1 y2, .. f xn yn]
 -/
 def flatCartesian {A B C : Type} (f : A -> B -> C) (xs : Array A) (ys : Array B) : Array C :=
 arrayBind xs (fun x => ys.map (fun y => f x y))
@@ -119,12 +119,12 @@ arrayBind xs (fun x => ys.map (fun y => f x y))
 If there are any measure that fit in the specified width, keep only those.
 If there aren't, keep the single least wide (the one that will overflow the least)
 -/
-partial def discardInvalid (w : Nat) (sils: Array Measure): Array Measure :=
+partial def discardInvalid (w : Nat) (sils: Array Measure'): Array Measure' :=
   let fit := sils.filter (fun s => s.fits w)
-  if fit.size > 0 then fit else 
+  if fit.size > 0 then fit else
   match sils.get? 0 with
   | none => panic "discardInvalid should never get an empty array"
-  | some hd => #[sils.foldl (fun least challenger => 
+  | some hd => #[sils.foldl (fun least challenger =>
     if challenger.maxWidth < least.maxWidth || (least.maxWidth = challenger.maxWidth && (least <= challenger))
     then challenger
     else least) hd]
@@ -132,8 +132,8 @@ partial def discardInvalid (w : Nat) (sils: Array Measure): Array Measure :=
 /--
 Deduplicate a sorted array of measures
 -/
-partial def dedupSorted (rem: Array Measure) : Array Measure :=
-  let rec aux (n : Nat) (out: Array Measure) : Array Measure :=
+partial def dedupSorted (rem: Array Measure') : Array Measure' :=
+  let rec aux (n : Nat) (out: Array Measure') : Array Measure' :=
   match rem.get? n, rem.get? n.succ with
   | none, _ => out
   | some x, none => out.push x
@@ -141,27 +141,27 @@ partial def dedupSorted (rem: Array Measure) : Array Measure :=
   aux 0 #[]
 
 /--
-From a list of measures, remove all those that are dominated 
+From a list of measures, remove all those that are dominated
 since we know they're not going to give an optimal layout
 -/
-partial def dominant (rem: Array Measure) : Array Measure :=
-  let rec aux (n : Nat) (out : Array Measure) : Array Measure :=
+partial def dominant (rem: Array Measure') : Array Measure' :=
+  let rec aux (n : Nat) (out : Array Measure') : Array Measure' :=
   match rem.get? n with
   | none => out
   | some x => if out.any (fun m => m.dominates x) then aux n.succ out else aux n.succ (out.push x)
   aux 0 #[]
 
 
-def sort (input : Array Measure) : Array Measure := input.qsort (fun m1 m2 => Measure.lt m1 m2)
+def sort (input : Array Measure') : Array Measure' := input.qsort (fun m1 m2 => Measure'.lt m1 m2)
 
-def pareto (w : Nat) : Array Measure -> Array Measure := dominant ∘ dedupSorted ∘ sort ∘ (discardInvalid w)
+def pareto (w : Nat) : Array Measure' -> Array Measure' := dominant ∘ dedupSorted ∘ sort ∘ (discardInvalid w)
 
 /-
 Calculate the measures for different possible horizontal groups.
-This is the regular one where the LAST element is the only one 
+This is the regular one where the LAST element is the only one
 allowed to be non-zero height
 
-From 
+From
 [
   [a1, a2, a3],
   [b1, b2, b3],
@@ -171,17 +171,17 @@ From
 [(a1, b1, c1), (a1, b1, c2), .., (a3, b3, c3)]
 -/
 def measureH
-  (grps : Array (Nat × (Array Measure))) 
-  (width : Nat) 
-  (sep : Measure) 
-  : Array Measure := 
+  (grps : Array (Nat × (Array Measure')))
+  (width : Nat)
+  (sep : Measure')
+  : Array Measure' :=
 match grps.back? with
 | none => #[]
-| some ⟨_, hd⟩ => 
+| some ⟨_, hd⟩ =>
   match zeroHeights (grps.toSubarray 0 (grps.size - 1)) with
   | none => #[]
-  | some rest => 
-  let concat_sep := fun (s1 s2 : Measure) => (s1.concat sep).concat s2
+  | some rest =>
+  let concat_sep := fun (s1 s2 : Measure') => (s1.concat sep).concat s2
   let inner := rest.foldr (fun next sink => pareto width $ flatCartesian concat_sep next sink) hd
   inner.map (fun measure => measure.cons (Choice.H measure.lastWidth))
 
@@ -189,25 +189,25 @@ match grps.back? with
 -- The irregular one for text.
 -- The FIRST element is the only one allowed to be non-zero height
 def measureT
-  (grps : Array (Nat × (Array Measure))) 
-  (width : Nat) 
-  (sep : Measure) 
-  : Array Measure := 
+  (grps : Array (Nat × (Array Measure')))
+  (width : Nat)
+  (sep : Measure')
+  : Array Measure' :=
 match grps.get? 0 with
 | none => #[]
-| some ⟨_, hd⟩ => 
+| some ⟨_, hd⟩ =>
   match zeroHeights (grps.toSubarray 1 (grps.size)) with
   | none => #[]
-  | some rest => 
+  | some rest =>
   let concat_sep := fun m1 m2 => (m1.concat sep).concat m2
   let inner := rest.foldl (fun sink next => pareto width $ flatCartesian concat_sep sink next) hd
   inner.map (fun measure => measure.cons (Choice.T))
 
-  
+
 /-
 Calculate the measures for different possible vertical groups.
 
-From 
+From
 [
   [a1, a2, a3],
   [b1, b2, b3],
@@ -217,17 +217,16 @@ From
 [(a1, b1, c1), (a1, b1, c2), .., (a3, b3, c3)]
 -/
 def measureV
-  (grps : Array (Nat × (Array Measure))) 
-  (width : Nat) 
-  : Array Measure := 
+  (grps : Array (Nat × (Array Measure')))
+  (width : Nat)
+  : Array Measure' :=
 -- for each x in [x1, x2, .. xn], indent it by the proper amount by concatenating
 -- some chunk on the left hand side.
-let indented := grps.map (fun ⟨amt, grp⟩ => grp.map (fun x => (Measure.mk 0 amt 0 DList.empty).concat x))
+let indented := grps.map (fun ⟨amt, grp⟩ => grp.map (fun x => (Measure'.mk 0 amt 0 DList.empty).concat x))
 match indented.get? 0 with
 | none => #[]
-| some hd => 
+| some hd =>
   let rest := indented.toSubarray 1 (grps.size)
-  let concat_nl := fun (s1 s2 : Measure) => s1.vConcat s2
+  let concat_nl := fun (s1 s2 : Measure') => s1.vConcat s2
   let inner := rest.foldl (fun sink next => pareto width $ flatCartesian concat_nl sink next) hd
   inner.map (fun measure => measure.cons (Choice.V measure.lastWidth))
-

--- a/Printiest/Tests.lean
+++ b/Printiest/Tests.lean
@@ -11,7 +11,7 @@ instance : Coe String Sexpr := ⟨Sexpr.atom⟩
 
 partial def Sexpr.pretty : Sexpr -> Doc
 | atom s => Doc.Text s
-| list es => 
+| list es =>
   let inner := Doc.group (es.map pretty) " "
   "(" <> inner <> ")"
 
@@ -26,9 +26,9 @@ def anSexpr : Sexpr := list #[
 ]
 
 -- The canonical "Prettiest" Sexpr demo
-#eval IO.Prim.getStdout >>= anSexpr.pretty.renderStream 15
-#eval IO.Prim.getStdout >>= anSexpr.pretty.renderStream 40
-#eval IO.Prim.getStdout >>= anSexpr.pretty.renderStream 80
+#eval IO.getStdout >>= anSexpr.pretty.renderStreamB 15
+#eval IO.getStdout >>= anSexpr.pretty.renderStreamB 40
+#eval IO.getStdout >>= anSexpr.pretty.renderStreamB 80
 
 def bigSexpr0 := list #[anSexpr, anSexpr, anSexpr, anSexpr]
 def bigSexpr1 := list #[bigSexpr0, bigSexpr0, bigSexpr0, bigSexpr0]
@@ -44,9 +44,9 @@ def bigSexprTest (w : Nat) := bigSexpr6.pretty.renderString w
 
 -- Demo of the groupText thing.
 def lorem := "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
-#eval IO.Prim.getStdout >>= (groupTextFromString lorem).renderStream 20
-#eval IO.Prim.getStdout >>= (groupTextFromString lorem).renderStream 40
-#eval IO.Prim.getStdout >>= (groupTextFromString lorem).renderStream 80
+#eval IO.getStdout >>= (groupTextFromString lorem).renderStreamB 20
+#eval IO.getStdout >>= (groupTextFromString lorem).renderStreamB 40
+#eval IO.getStdout >>= (groupTextFromString lorem).renderStreamB 80
 
 namespace test1
 def L : Doc := "points:"
@@ -56,10 +56,10 @@ def R := Doc.group #["1. first point", "2. second point", "3. third point"] " "
 The two hang operators; "alwaysHang" and "hang", where the latter will only
 do hanging indentation if the given width can't fit everything on one line.
 -/
-#eval IO.Prim.getStdout >>= (hang 4 L R).renderStream 80
-#eval IO.Prim.getStdout >>= (hang 4 L R).renderStream 20
-#eval IO.Prim.getStdout >>= (alwaysHang 4 L R).renderStream 80
-#eval IO.Prim.getStdout >>= (alwaysHang 4 L R).renderStream 20
+#eval IO.getStdout >>= (hang 4 L R).renderStreamB 80
+#eval IO.getStdout >>= (hang 4 L R).renderStreamB 20
+#eval IO.getStdout >>= (alwaysHang 4 L R).renderStreamB 80
+#eval IO.getStdout >>= (alwaysHang 4 L R).renderStreamB 20
 end test1
 
 /-
@@ -94,10 +94,10 @@ def gitOptions : List String :=
 ]
 
 def helpText := "'git help -a' and 'git help -g' list available subcommands and some concept guides. See 'git help <command>' or 'git help <concept>' to read about a specific subcommand or concept. See 'git help git' for an overview of the system."
-def gitCli := 
+def gitCli :=
   let grp := group #["git" <+> groupText gitOptions, "<command>", "[<args>]"] " "
   (hang 4 "usage:" grp)
-  <n> Nil 
+  <n> Nil
   <n> groupTextFromString helpText
 
 /-
@@ -105,18 +105,17 @@ Recreates a portion of the `git --help` output showing the ability
 to render a CLI to best fit a given terminal width (ideally this would be
 read from the user's terminal and then printed accordingly).
 -/
-#eval IO.Prim.getStdout >>= gitCli.renderStream 80
-#eval IO.Prim.getStdout >>= gitCli.renderStream 40
-#eval IO.Prim.getStdout >>= gitCli.renderStream 20
+#eval IO.getStdout >>= gitCli.renderStreamB 80
+#eval IO.getStdout >>= gitCli.renderStreamB 40
+#eval IO.getStdout >>= gitCli.renderStreamB 20
 
 -- Demo of the helper function for creating a separated and surrounded list of items.
-#eval IO.Prim.getStdout >>= (Doc.encloseSep "{" (gitOptions.map (fun x => Doc.Text x)).toArray "," "}" 4).renderStream 40
+#eval IO.getStdout >>= (Doc.encloseSep "{" (gitOptions.map (fun x => Doc.Text x)).toArray "," "}" 4).renderStreamB 40
 
 -- Force a group to be horizontal
 def restrict_h := Doc.group (kind := GroupKind.horizontalCode) #["A", "B", "C"] ", "
-#eval IO.Prim.getStdout >>= restrict_h.renderStream 1
+#eval IO.getStdout >>= restrict_h.renderStreamB 1
 
 -- Force a group to be vertical
 def restrict_v := Doc.group (kind := GroupKind.vertical) #["A", "B", "C"] " "
-#eval IO.Prim.getStdout >>= restrict_v.renderStream 40
-
+#eval IO.getStdout >>= restrict_v.renderStreamB 40

--- a/Printiest/Util.lean
+++ b/Printiest/Util.lean
@@ -1,4 +1,4 @@
-      
+
 inductive Choice
 | H : Nat -> Choice
 | V : Nat -> Choice
@@ -14,7 +14,7 @@ def Choice.toString (c : Choice) : String :=
 instance : ToString Choice := ⟨Choice.toString⟩
 
 /-
-Side and Spaces are helper types to keep track of info during rendering; 
+Side and Spaces are helper types to keep track of info during rendering;
 we need these to allow for streaming output.
 
 Side keeps track of whether we're on the left or right side of a Concat
@@ -33,13 +33,13 @@ inductive Spaces
 | Hot : Nat -> Spaces
 | Cold : Nat -> Spaces
 
-instance : Inhabited Spaces := ⟨Spaces.Cold 0⟩ 
+instance : Inhabited Spaces := ⟨Spaces.Cold 0⟩
 
-def Spaces.toHot : Spaces -> Spaces 
+def Spaces.toHot : Spaces -> Spaces
 | Hot n => Hot n
 | Cold n => Hot n
 
-def Spaces.toCold : Spaces -> Spaces 
+def Spaces.toCold : Spaces -> Spaces
 | Hot n => Cold n
 | Cold n => Cold n
 
@@ -67,7 +67,7 @@ instance {A : Type} : Stream (RenderState A) Choice where
   | [] => none
   | hd :: tl => some (hd, { rs with choices := tl })
 
-def RenderState.new {A : Type} (a : A) (choices: List Choice) : RenderState A := 
+def RenderState.new {A : Type} (a : A) (choices: List Choice) : RenderState A :=
   ⟨a, choices, Left, Cold 0⟩
 
 instance : Inhabited (RenderState String) := ⟨RenderState.new "" []⟩
@@ -83,7 +83,7 @@ instance : HasWrite String Id := {
 }
 
 instance : HasWrite IO.FS.Stream IO := {
-  tell := 
+  tell :=
   fun s st => do
   st.sink.write s.toUTF8
   return ((), st)

--- a/leanpkg.toml
+++ b/leanpkg.toml
@@ -1,4 +1,0 @@
-[package]
-name = "Printiest"
-version = "0.1"
-lean_version = "leanprover/lean4:nightly-2021-04-26"


### PR DESCRIPTION
Solution:

 - Since getStdout is now BaseIO, we need to have a way to have a BaseIO function for FS-based stream pretty printing.
 - We also have updated toolchain specification to use modern spec files.
 - Explicitly import std in lakefile.lean.

Cosmetics:

 - Delete some trailing whitespaces.


PS

Feel free to merge or not, since here we're using November's Lean, which doesn't have many incompatibilities with the modern Lean, but eventually we'll bump all the way to Jan 10th release.